### PR TITLE
Update to node-amqp10 3.3.1

### DIFF
--- a/lib/connection.d.ts
+++ b/lib/connection.d.ts
@@ -116,8 +116,14 @@ import Session = require("./session");
  */
 declare class Connection extends EventEmitter {
     policy: Policy.Connect;
+    connected: boolean;
+    connectedTo: any;
+
+    local: any;
+    remote: any;
+
     connSM: any;
-    
+
     static Connected: "connection:connected";
     static Disconnected: "connection:disconnected";
     /**
@@ -131,15 +137,15 @@ declare class Connection extends EventEmitter {
      * received AMQPError as an argument.
      */
     static ErrorReceived: "connection:errorReceived";
-    
+
     /**
      * Creates a new Connection instance.
-     * 
+     *
      * @param connectPolicy ConnectPolicy from a Policy instance
      * @constructor
      */
     constructor(connectPolicy: Policy.Connect);
-    
+
     /**
      * Open a connection to the given (parsed) address (@see {@link AMQPClient}).
      *
@@ -147,14 +153,14 @@ declare class Connection extends EventEmitter {
      * @param sasl      If given, contains a "negotiate" method that, given address and a callback, will run through SASL negotiations.
      */
     open(address: Policy.Address, sasl?: { negotiate(address: Policy.Address, callback: Function): void; }): void;
-    
+
     close(): void;
-    
+
     sendFrame(frame: any): void;
-    
+
     associateSession(session: Session): number;
     dissociateSession(channel: number): void;
-    
+
     sendHeader(header: Buffer): void;
 }
 

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -8,7 +8,7 @@ export class BaseError extends Error {
     name: string;
     message: string;
     stack: string;
-    
+
     constructor(message: string);
 }
 
@@ -17,28 +17,28 @@ export class ProtocolError extends BaseError {
     condition: string;
     description: string;
     errorInfo: any;
-    
+
     constructor(condition: string, description?: string, errorInfo?: any);
 }
 
 /** AMQP Header is malformed. */
 export class MalformedHeaderError extends BaseError {
     name: "AmqpMalformedHeaderError";
-    
+
     constructor(header: string);
 }
 
 /** Method or feature is not yet implemented. */
 export class NotImplementedError extends BaseError {
     name: "AmqpNotImplementedError";
-    
+
     constructor(feature: string);
 }
 
 /** Payload is malformed or cannot be parsed. */
 export class MalformedPayloadError extends BaseError {
     name: "AmqpMalformedPayloadError";
-    
+
     constructor(payload: string);
 }
 
@@ -46,7 +46,7 @@ export class MalformedPayloadError extends BaseError {
 export class EncodingError extends BaseError {
     name: "AmqpEncodingError";
     value: any;
-    
+
     /**
      * @param value - The value that caused the encoding error.
      * @param message - An optional message giving context to the error.
@@ -57,48 +57,66 @@ export class EncodingError extends BaseError {
 /** Violation of AMQP flow control. */
 export class OverCapacityError extends BaseError {
     name: "AmqpOverCapacityError";
-    
+
     constructor(msg: string);
 }
 
 /** Authentication failure. */
 export class AuthenticationError extends BaseError {
     name: "AmqpAuthenticationError";
-    
+
     constructor(msg: string);
 }
 
 /** Argument missing or incorrectly defined. */
 export class ArgumentError extends BaseError {
     name: "AmqpArgumentError";
-    
+
     constructor(arg: string |string[]);
 }
 
 /** Invalid state. */
 export class InvalidStateError extends BaseError {
     name: "AmqpInvalidStateError";
-    
+
     constructor(msg: string);
 }
 
 /** Connection error. */
 export class ConnectionError extends BaseError {
     name: "AmqpConnectionError";
-    
+
     constructor(msg: string);
 }
 
 /** Disconnected error. */
 export class DisconnectedError extends BaseError {
     name: "AmqpDisconnectedError";
-    
+
     constructor(msg: string);
 }
 
 /** AMQP Version error. */
 export class VersionError extends BaseError {
     name: "AmqpVersionError";
-    
+
+    constructor(msg: string);
+}
+
+/**
+ * Invalid subject specified for receiver or sender link creation.
+ */
+export class InvalidSubjectError extends BaseError {
+    name: "AmqpInvalidSubjectError";
+
+    constructor(subject: string);
+}
+
+/**
+ * Used to signal transport-related errors
+ */
+export class TransportError extends BaseError {
+    name: "AmqpTransportError";
+
     constructor(msg: string);
 }

--- a/lib/frames.d.ts
+++ b/lib/frames.d.ts
@@ -1,0 +1,122 @@
+/**
+ * Types only
+ */
+export interface Frame {
+    type: number;
+}
+
+export interface OpenFrame {
+    containerId: string;
+    hostname: string;
+    maxFrameSize: number;
+    channelMax: number;
+    idleTimeout: number;
+    outgoingLocales: string;
+    incomingLocales: string;
+    offeredCapabilities: string;
+    desiredCapabilities: string;
+    properties: Object;
+}
+
+export interface BeginFrame {
+    remoteChannel: number;
+    nextOutgoingId: number;
+    incomingWindow: number;
+    outgoingWindow: number;
+    handleMax: number;
+    offeredCapabilities: string;
+    desiredCapabilities: string;
+    properties: Object;
+}
+
+export interface AttachFrame {
+    name: string;
+    handle: string;
+    role: boolean;
+    sndSettleMode: string;
+    rcvSettleMode: string;
+    source: any;
+    target: any;
+    unsettled: { [key: string]: any };
+    incompleteUnsettled: boolean;
+    initialDeliveryCount: number;
+    maxMessageSize: number;
+    offeredCapabilities: string;
+    desiredCapabilities: string;
+    properties: Object;
+}
+
+export interface FlowFrame {
+    nextIncomingId: number;
+    incomingWindow: number;
+    nextOutgoingId: number;
+    outgoingWindow: number;
+    handle: string;
+    deliveryCount: number;
+    linkCredit: number;
+    available: number;
+    drain: boolean;
+    echo: boolean;
+    properties: Object;
+}
+
+export interface TransferFrame {
+    handle: string;
+    deliveryId: number;
+    deliveryTag: number;
+    messageFormat: number;
+    settled: boolean;
+    more: boolean;
+    rcvSettleMode: number;
+    state: any;
+    resume: boolean;
+    aborted: boolean;
+    batchable: boolean;
+}
+
+export interface DispositionFrame {
+    role: boolean;
+    first: number;
+    last: number;
+    settled: number;
+    state: any;
+    batchable: boolean;
+}
+
+export interface DetachFrame {
+    handle: string;
+    closed: boolean;
+    error: any;
+}
+
+export interface EndFrame {
+    error: any;
+}
+
+export interface CloseFrame {
+    error: any;
+}
+
+// SASL frames
+export interface SaslMechanismsFrame {
+    saslServerMechanisms: string;
+}
+
+export interface SaslInitFrame {
+    mechanism: string;
+    initialResponse: Buffer; // Is this right?
+    hostname: string;
+}
+
+export interface SaslChallengeFrame {
+    challenge: Buffer; // Is this right?
+}
+
+export interface SaslResponseFrame {
+    response: Buffer; // Is this right?
+}
+
+export interface SaslOutcomeFrame {
+    code: number;
+    additionalData: Buffer;
+}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,31 +23,31 @@ export import Errors = require("./errors");
 export namespace Policy {
     export import PolicyBase = _Policy;
     export const Default: _Policy;
-    
+
     export const EventHub: typeof _EventHub;
     export const ServiceBusQueue: typeof _ServiceBusQueue;
     export const ServiceBusTopic: typeof _ServiceBusTopic;
     export const QpidJava: typeof _QpidJava;
     export const ActiveMQ: typeof _ActiveMQ;
-    
+
     export import Utils = _Utils;
-    
+
     /**
      * Create a new Policy by extending the Base Policy.
-     * 
+     *
      * @param overrides - Configuration overrides.
      * @returns Extended configuration.
      */
     export function merge(overrides: Options.Overrides): PolicyBase
     /**
      * Create a new Policy by extending given base policy using given overrides configuration.
-     * 
+     *
      * @param overrides - Configuration overrides.
      * @param base - Base configuration to extend.
      * @returns Extended configuration.
      */
     export function merge(overrides: Options.Overrides, base: PolicyBase): PolicyBase;
-    
+
     /** Typings only */
     export namespace Options {
         export type Overrides = _Policy.Overrides;
@@ -66,6 +66,7 @@ export namespace Policy {
 }
 
 export import TransportProvider = require("./transport/index");
+export import DescribedType = require("./types/described_type");
 
 /**
  * translator, which allows you to translate from node-amqp-encoder'd

--- a/lib/link.d.ts
+++ b/lib/link.d.ts
@@ -14,15 +14,16 @@ declare class Link extends EventEmitter {
     session: Session;
     handle: string;
     remote: Link.Remote;
+    deliveryCount: number;
     linkSM: any;
-    
+
     name: string;
     role: boolean;
     linkCredit: number;
     totalCredits: number;
     available: number;
     drain: boolean;
-    
+
     /** On receipt of a message.  Message payload given as argument. */
     static MessageReceived: "message";
 
@@ -40,14 +41,15 @@ declare class Link extends EventEmitter {
 
     /** On completion of detach. */
     static Detached: "detached";
-    
+
     constructor(session: Session, handle: string, linkPolicy: LinkPolicy);
-    
+
     state(): string;
     attach(): void;
-    detach(): Promise<void>;
+    detach(options?: Link.DetachOptions): Promise<void>;
     forceDetach(): void;
-    flow(flowOptions: Link.FlowOptions): void;
+    flow(flowOptions?: Link.FlowOptions): void;
+    shouldReatttach(): boolean;
 }
 
 declare namespace Link {
@@ -56,7 +58,7 @@ declare namespace Link {
         attach: any;
         detach: any;
     }
-    
+
     export interface FlowOptions {
         channel?: string;
         handle?: string;
@@ -68,6 +70,13 @@ declare namespace Link {
         available?: boolean;
         deliveryCount?: number;
         drain?: boolean;
+    }
+
+    export interface DetachOptions {
+        handle?: string;
+        channel?: string;
+        closed?: boolean;
+        error?: any;
     }
 }
 

--- a/lib/receiver_link.d.ts
+++ b/lib/receiver_link.d.ts
@@ -8,24 +8,27 @@ import Session = require("./session");
 import Policy = require("./policies/policy");
 import { DeliveryState } from "./types/delivery_state";
 import { BaseError } from "./errors";
+import { TransferFrame } from "./frames";
 
 type Message = ReceiverLink.Message;
 
 declare class ReceiverLink extends Link {
     policy: Policy.ReceiverLink;
     settledMessagesSinceLastCredit: number;
-    
+    linkCredits: number;
+    totalCredits: number;
+
     constructor(session: Session, handle: string, linkPolicy: Policy.ReceiverLink);
 
     addCredits(credits: number, flowOptions?: Link.FlowOptions): void;
-    
+
     /**
      * Settle a message (or array of messages) with an Accepted delivery outcome
      *
      * @param {String|Array}  [message] message, or array of messages to settle
      */
     accept(message?: Message | Message[]): void;
-    
+
     /**
      * Settle a message (or array of messages) with a Rejected delivery outcome
      *
@@ -33,14 +36,14 @@ declare class ReceiverLink extends Link {
      * @param {String}        [error] error that caused the message to be rejected
      */
     reject(message?: Message | Message[], error?: string): void;
-    
+
     /**
      * Settle a message (or array of messages) with a Released delivery outcome
      *
      * @param {String|Array}  [message] message, or array of messages to settle
      */
     release(message?: Message | Message[]): void;
-    
+
     /**
      * Settle a message (or array of messages) with a Modified delivery outcome
      *
@@ -48,7 +51,7 @@ declare class ReceiverLink extends Link {
      * @param {Object}        [options] options used for a Modified outcome
      */
     modify(message?: Message | Message[], options?: ReceiverLink.ModifyOptions): void;
-    
+
     /**
      * Settle a message (or array of messages) with a given delivery state
      *
@@ -56,35 +59,36 @@ declare class ReceiverLink extends Link {
      * @param {Object}        [state] outcome of message delivery
      */
     settle(message?: Message | Message[], state?: DeliveryState): void;
-    
+
     /** Message event handler */
-    on(event: "message", listener: (msg: Message) => void): this;
+    on(event: "message", listener: (msg: Message, frame: TransferFrame) => void): this;
     /** Error event handler */
     on(event: "errorReceived", listener: (err: BaseError) => void): this;
+    on(event: "creditChange" | "attached" | "detached", listener: Function): this;
     on(event: string, listener: Function): this;
 }
 
 declare namespace ReceiverLink {
-    export interface Dictionary<T> { 
+    export interface Dictionary<T> {
         [key: string]: T;
     }
-    
+
     export interface ModifyOptions {
         /** count the transfer as an unsuccessful delivery attempt. */
         deliveryFailed?: boolean;
-        
+
         /** prevent redelivery. */
         undeliverableHere?: boolean;
-        
+
         /** message attributes to combine with existing annotations. */
         messageAnnotations?: Object;
     }
-    
+
     export interface Message extends Dictionary<any> {
         body?: any;
-        
+
         properties?: Dictionary<any>;
-        
+
         /**
          * Annotations for the message, if any.  See AMQP spec for details, and server for specific
          * annotations that might be relevant (e.g. x-opt-partition-key on EventHub).  If node-amqp-encoder'd
@@ -92,7 +96,7 @@ declare namespace ReceiverLink {
          * to AMQP Fields type as defined in the spec.
          */
         annotations?: Dictionary<any>;
-        
+
         applicationProperties?: Dictionary<any>;
     }
 }

--- a/lib/sender_link.d.ts
+++ b/lib/sender_link.d.ts
@@ -11,11 +11,12 @@ import { BaseError } from "./errors";
 
 declare class SenderLink extends Link {
     policy: Policy.SenderLink;
+    initialDeliveryCount: number;
 
     constructor(session: Session, handle: string, linkPolicy: Policy.SenderLink);
 
     canSend(): boolean;
-    
+
     /**
      * Sends the given message, with the given options on this link
      *
@@ -28,22 +29,23 @@ declare class SenderLink extends Link {
     *                               to AMQP Fields type as defined in the spec.
     */
     send(message: any, options?: SenderLink.MessageOptions | Object): Promise<DeliveryState>;
-    
+
     /** Error event handler */
     on(event: "errorReceived", listener: (err: BaseError) => void): this;
+    on(event: "creditChange" | "attached" | "detached", listener: Function): this;
     on(event: string, listener: Function): this;
 }
 
 declare namespace SenderLink {
-    export interface Dictionary<T> { 
+    export interface Dictionary<T> {
         [key: string]: T;
     }
-    
+
     export interface MessageOptions extends Dictionary<any> {
         body: any;
-        
+
         properties?: Dictionary<any>;
-        
+
         /**
          * Annotations for the message, if any.  See AMQP spec for details, and server for specific
          * annotations that might be relevant (e.g. x-opt-partition-key on EventHub).  If node-amqp-encoder'd
@@ -51,7 +53,7 @@ declare namespace SenderLink {
          * to AMQP Fields type as defined in the spec.
          */
         annotations?: Dictionary<any>;
-        
+
         applicationProperties?: Dictionary<any>;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-amqp10",
-  "version": "3.1.4",
+  "version": "3.3.1",
   "description": "Type definitions for https://github.com/noodlefrenzy/node-amqp10",
   "main": "index.js",
   "author": "typed-contrib",

--- a/typings.json
+++ b/typings.json
@@ -1,9 +1,9 @@
 {
     "name": "amqp10",
     "main": "lib/index.d.ts",
-    "version": "3.1.4",
+    "version": "3.3.1",
     "globalDependencies": {
         "es2015-promise": "registry:env/es2015-promise#1.0.0+20160526151700",
-        "node": "registry:dt/node#6.0.0+20160514165920"
+        "node": "registry:env/node#6.0.0+20161019193037"
     }
 }


### PR DESCRIPTION
Notable changes:
- `DescribedType` is now exported from `index.d.ts`
- On message received in `ReceiverLink`, the `TransferFrame` is now passed as the second parameter to the listener.
- Add typings for options on link `detach()`
- Move from deprecated node dt typings to env typings

I tried to make a through pass through the root files in the package, but didn't have a chance to go through the subfolders much.
